### PR TITLE
Replace native title tooltips with daisyUI tooltips

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -61,7 +61,7 @@ const { title = 'PetaTas' } = Astro.props;
                     </button>
                   </li>
                   <li>
-                    <button id="clear-all-button" data-testid="clear-all-button" title="Clear all tasks">
+                    <button id="clear-all-button" data-testid="clear-all-button" class="tooltip" data-tip="Clear all tasks">
                       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-4 h-4">
                         <path d="M9 3h6l1 2h4v2H4V5h4l1-2zm1 7h2v8h-2v-8zm4 0h2v8h-2v-8z"/>
                       </svg>

--- a/src/panel-client.ts
+++ b/src/panel-client.ts
@@ -729,7 +729,8 @@ class PetaTasClient {
     const timerButton = existingRow.querySelector('button[data-action="timer"]') as HTMLButtonElement | null;
     if (timerButton) {
       timerButton.innerHTML = isTimerRunning ? PAUSE_SVG : PLAY_SVG;
-      timerButton.setAttribute('title', isTimerRunning ? 'Pause timer' : 'Start timer');
+      timerButton.classList.add('tooltip');
+      timerButton.setAttribute('data-tip', isTimerRunning ? 'Pause timer' : 'Start timer');
       timerButton.setAttribute('aria-label', isTimerRunning ? 'Pause timer' : 'Start timer');
       const disable = task.status === 'done'
       timerButton.disabled = disable
@@ -818,9 +819,10 @@ class PetaTasClient {
         // keep as-is
       }
 
-      // Tooltip and aria semantics
+      // Tooltip and aria semantics (daisyUI)
       badge.setAttribute('aria-label', aria)
-      badge.setAttribute('title', text)
+      badge.classList.add('tooltip')
+      badge.setAttribute('data-tip', text)
     }
 
     // Disable/enable timer button based on status
@@ -839,9 +841,10 @@ class PetaTasClient {
       return;
     }
 
-    // Update button text and title
+    // Update button text and tooltip
     timerButton.innerHTML = isRunning ? PAUSE_SVG : PLAY_SVG;
-    timerButton.setAttribute('title', isRunning ? 'Pause timer' : 'Start timer');
+    timerButton.classList.add('tooltip');
+    timerButton.setAttribute('data-tip', isRunning ? 'Pause timer' : 'Start timer');
     timerButton.setAttribute('aria-label', isRunning ? 'Pause timer' : 'Start timer');
   }
 
@@ -860,7 +863,7 @@ class PetaTasClient {
             const title = `${escapeHtmlAttribute(header)}: ${escapeHtmlAttribute(value)}`
             // Badge: limit width to container and show tooltip; inner span handles ellipsis
             return `
-            <span class="badge badge-md mr-1 mb-1 align-middle max-w-full" title="${title}">
+            <span class="badge badge-md mr-1 mb-1 align-middle max-w-full tooltip" data-tip="${title}">
               <span class="inline-block truncate max-w-full">${label}</span>
             </span>
           `
@@ -877,23 +880,23 @@ class PetaTasClient {
             ${task.status === 'done' ? 'checked' : ''}
             data-task-id="${escapeHtml(task.id)}"
             />
-            <span class="status-badge badge badge-md align-middle ${this.getStatusBadge(task.status).cls}" aria-label="${this.getStatusBadge(task.status).aria}" title="${this.getStatusBadge(task.status).text}">
+            <span class="status-badge badge badge-md align-middle ${this.getStatusBadge(task.status).cls} tooltip" aria-label="${this.getStatusBadge(task.status).aria}" data-tip="${this.getStatusBadge(task.status).text}">
               ${this.getStatusBadge(task.status).icon}
             </span>
             <div class="timer-controls flex items-center gap-2 ml-2 shrink-0">
               <div class="timer-display ${isTimerRunning ? 'running' : ''} self-end md:self-auto">${elapsedTime}</div>
               <input 
                 type="number" 
-                class="timer-minutes-input input input-bordered input-xs w-12 text-center"
+                class="timer-minutes-input input input-bordered input-xs w-12 text-center tooltip"
                 value="${Math.round(task.elapsedMs / 60000)}"
                 min="0"
                 step="1"
                 placeholder="min"
-                title="Enter time in minutes"
+                data-tip="Enter time in minutes"
                 data-task-id="${escapeHtml(task.id)}"
                 data-action="set-minutes"
               />
-              <button class="btn btn-ghost btn-xs" data-task-id="${escapeHtml(task.id)}" data-action="timer" title="${isTimerRunning ? 'Pause timer' : 'Start timer'}" aria-label="${isTimerRunning ? 'Pause timer' : 'Start timer'}" ${task.status === 'done' ? 'disabled aria-disabled="true"' : ''}>
+              <button class="btn btn-ghost btn-xs tooltip" data-task-id="${escapeHtml(task.id)}" data-action="timer" data-tip="${isTimerRunning ? 'Pause timer' : 'Start timer'}" aria-label="${isTimerRunning ? 'Pause timer' : 'Start timer'}" ${task.status === 'done' ? 'disabled aria-disabled="true"' : ''}>
                 ${isTimerRunning ? PAUSE_SVG : PLAY_SVG}
               </button>
             </div>
@@ -912,7 +915,7 @@ class PetaTasClient {
           </div>
         </div>
         </div>
-        <button class="absolute top-2 right-2 btn btn-ghost btn-xs text-base-content/60 hover:text-error hover:bg-error/10" data-task-id="${escapeHtml(task.id)}" data-action="delete" title="Delete task">
+        <button class="absolute top-2 right-2 btn btn-ghost btn-xs text-base-content/60 hover:text-error hover:bg-error/10 tooltip" data-task-id="${escapeHtml(task.id)}" data-action="delete" data-tip="Delete task">
           ×
         </button>
       </div>

--- a/tests/features/detail-badge-ellipsis.test.ts
+++ b/tests/features/detail-badge-ellipsis.test.ts
@@ -60,7 +60,7 @@ describe('Detail badges truncate text and show tooltip', () => {
     dom.window.close()
   })
 
-  it('renders detail badges with ellipsis and a tooltip title', async () => {
+  it('renders detail badges with ellipsis and a daisyUI tooltip', async () => {
     vi.resetModules()
     await import('../../src/panel-client.ts')
 
@@ -73,9 +73,10 @@ describe('Detail badges truncate text and show tooltip', () => {
     expect(badges.length).toBeGreaterThan(0)
 
     for (const badge of badges) {
-      // Should have a title attribute for native tooltip
-      const title = badge.getAttribute('title')
-      expect(title && title.length).toBeGreaterThan(0)
+      // Should have daisyUI tooltip via data-tip and class
+      expect(badge.classList.contains('tooltip')).toBe(true)
+      const tip = badge.getAttribute('data-tip')
+      expect(tip && tip.length).toBeGreaterThan(0)
       // Should use truncation utility via inner span
       const inner = badge.querySelector('span') as HTMLElement | null
       expect(inner).toBeTruthy()
@@ -83,4 +84,3 @@ describe('Detail badges truncate text and show tooltip', () => {
     }
   })
 })
-

--- a/tests/features/tooltips.test.ts
+++ b/tests/features/tooltips.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+function readAllFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      files.push(...readAllFiles(full));
+    } else {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+describe('Tooltip migration to daisyUI', () => {
+  it('TypeScript sources should not use native title= for tooltips', () => {
+    const srcFiles = readAllFiles(join(process.cwd(), 'src'))
+      .filter(f => f.endsWith('.ts'));
+    const titleAttr = /\btitle\s*=\s*['"]/; // attribute usage inside string templates
+    const setAttrTitle = /setAttribute\(\s*['\"]title['\"]/;
+
+    for (const f of srcFiles) {
+      const text = readFileSync(f, 'utf8');
+      expect(titleAttr.test(text)).toBe(false);
+      expect(setAttrTitle.test(text)).toBe(false);
+    }
+  });
+
+  it('panel-client should use data-tip and tooltip classes', () => {
+    const panel = readFileSync(join(process.cwd(), 'src', 'panel-client.ts'), 'utf8');
+    expect(panel.includes('data-tip=')).toBe(true);
+    expect(panel.includes('tooltip')).toBe(true);
+    expect(panel.includes("setAttribute('data-tip'")).toBe(true);
+  });
+
+  it('index.astro should apply daisyUI tooltip to Clear All', () => {
+    const indexAstro = readFileSync(join(process.cwd(), 'src', 'pages', 'index.astro'), 'utf8');
+    expect(indexAstro.includes('data-tip="Clear all tasks"')).toBe(true);
+    expect(indexAstro.includes('tooltip')).toBe(true);
+    // should not use title="Clear all tasks"
+    expect(indexAstro.includes('title="Clear all tasks"')).toBe(false);
+  });
+});


### PR DESCRIPTION
- Replace all native title-based tooltips with daisyUI tooltip + data-tip.
- Update runtime DOM updates to set data-tip instead of title.
- Keep aria-labels for accessibility.
- Add tests to enforce the new pattern and adjust existing expectations.

Verified: npm test → all green.