### PR TITLE
fix: eliminate horizontal scroll; keep panel min-width 360px; remove main content px

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,7 +18,7 @@ const { title = 'PetaTas' } = Astro.props;
     <title>PetaTas - Task Manager</title>
   </head>
   <body>
-    <div id="panel-root" class="min-w-[360px]">
+    <div id="panel-root" class="min-w-[360px] w-full">
       <div class="drawer drawer-mobile">
         <div class="drawer-content">
           <!-- Navbar with controls -->
@@ -74,8 +74,8 @@ const { title = 'PetaTas' } = Astro.props;
           </div>
 
           <!-- Main content area -->
-          <div class="mx-auto px-4 py-0 flex-1 flex flex-col min-h-0 overflow-hidden max-w-none w-full">
-            <div class="flex-1 min-h-0 overflow-y-auto basis-0 pr-1">
+          <div class="mx-auto py-0 flex-1 flex flex-col min-h-0 overflow-hidden max-w-none w-full">
+            <div class="flex-1 min-h-0 overflow-y-auto overflow-x-hidden basis-0 pr-1">
               <!-- Empty state -->
               <div class="empty-state text-center py-8 flex flex-col items-center justify-center h-full" data-testid="empty-state" id="empty-state">
               <div class="text-base-content/70">

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4,12 +4,15 @@
 @tailwind utilities;
 
 /* Custom styles for the extension */
+html, body {
+  margin: 0;
+  padding: 0;
+}
 body {
   @apply bg-base-200 text-base-content;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-  margin: 0;
-  padding: 0;
   min-height: 100vh;
+  overflow-x: hidden;
 }
 
 #panel-root {

--- a/tests/pages/panel-min-width.test.ts
+++ b/tests/pages/panel-min-width.test.ts
@@ -2,12 +2,18 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
 
-describe('Side panel minimum width', () => {
-  it('ensures markup declares min-w-[360px] to match Chrome panel minimum', () => {
+describe('Side panel width constraints', () => {
+  it('declares min-w-[360px] to match Chrome panel minimum', () => {
     const file = resolve(process.cwd(), 'src/pages/index.astro')
     const content = readFileSync(file, 'utf8')
-    // Declare explicit minimum width for layout safety on narrow panels
-    expect(content).toMatch(/class=\"[^\"]*min-w-\[360px\][^\"]*\"/)
+    // Keep explicit minimum width to match Chrome panel behavior (attribute order agnostic)
+    expect(content).toMatch(/<div[^>]*(id=\"panel-root\"[^>]*class=\"[^\"]*min-w-\[360px\][^\"]*\"|class=\"[^\"]*min-w-\[360px\][^\"]*\"[^>]*id=\"panel-root\")/)
+  })
+
+  it('uses w-full on the root container', () => {
+    const file = resolve(process.cwd(), 'src/pages/index.astro')
+    const content = readFileSync(file, 'utf8')
+    // Fill the available panel width without exceeding it
+    expect(content).toMatch(/id=\"panel-root\"[^>]*class=\"[^\"]*\bw-full\b[^\"]*\"/)
   })
 })
-

--- a/tests/pages/panel-scrollbar-padding.test.ts
+++ b/tests/pages/panel-scrollbar-padding.test.ts
@@ -3,13 +3,14 @@ import { readFileSync } from 'fs'
 import { resolve } from 'path'
 
 describe('Panel scrollbar padding', () => {
-  it('adds right padding inside the overflow container to space content from scrollbar', () => {
+  it('removes main content horizontal padding; keeps right padding only on the scroll container', () => {
     const file = resolve(process.cwd(), 'src/pages/index.astro')
     const content = readFileSync(file, 'utf8')
     // Ensure the vertical scroll container has a small right padding (pr-1)
     expect(content).toMatch(/class=\"[^\"]*overflow-y-auto[^\"]*pr-1/)
-    // Ensure the main content container has no vertical padding (no gap above/below list)
-    expect(content).toMatch(/class=\"[^\"]*mx-auto[^\"]*px-4[^\"]*py-0/)
+    // Ensure the main content container does NOT have horizontal padding (px-4 removed), but keeps py-0
+    expect(content).toMatch(/class=\"[^\"]*mx-auto[^\"]*py-0/)
+    expect(content).not.toMatch(/class=\"[^\"]*mx-auto[^\"]*px-4/)
     // Ensure the card list has top/bottom margin for spacing from body (attribute order agnostic)
     expect(content).toMatch(/<div[^>]*(id=\"task-list\"[^>]*class=\"[^\"]*\bmy-2\b|class=\"[^\"]*\bmy-2\b[^\"]*\"[^>]*id=\"task-list\")/)
   })

--- a/tests/styles/main-css-cleanup.test.ts
+++ b/tests/styles/main-css-cleanup.test.ts
@@ -26,4 +26,16 @@ describe('main.css cleanup for daisyUI compatibility', () => {
     expect(css).not.toMatch(/@media\s*\(prefers-color-scheme:\s*dark\)/)
     expect(css).not.toMatch(/color-scheme:\s*dark\s*;/)
   })
+
+  it('applies global horizontal overflow suppression on body', () => {
+    // Ensure we clip any accidental fixed/absolute elements outside panel root
+    expect(css).toMatch(/body\s*\{[\s\S]*?overflow-x:\s*hidden;[\s\S]*?\}/)
+  })
+
+  it('sets html/body margin and padding to zero', () => {
+    // Accept either a combined selector or separate rules; require both properties
+    const combined = /(html\s*,\s*body)\s*\{[\s\S]*?margin:\s*0;[\s\S]*?padding:\s*0;[\s\S]*?\}/
+    const htmlRule = /html\s*\{[\s\S]*?margin:\s*0;[\s\S]*?padding:\s*0;[\s\S]*?\}/
+    expect(combined.test(css) || htmlRule.test(css)).toBe(true)
+  })
 })


### PR DESCRIPTION
## 概要
- 横スクロールの発生を解消しつつ、Chrome 拡張サイドパネルの最小幅 (360px) は維持しました。
- Main content area の左右パディングを撤去しました。

Closes #32

## 変更点
- pages: `src/pages/index.astro`
  - `#panel-root` は `min-w-[360px] w-full` を維持。
  - メインラッパーから `px-4` を削除 (`mx-auto py-0 ...`)。
  - 縦スクロール領域に `overflow-x-hidden` を追加して横方向のはみ出しを遮断、`pr-1` は維持。
- styles: `src/styles/main.css`
  - `html, body { margin: 0; padding: 0; }` を追加。
  - `body { overflow-x: hidden; }` を維持（fixed 要素のはみ出し対策）。
- tests:
  - `tests/pages/panel-min-width.test.ts`: `#panel-root` に `min-w-[360px]` と `w-full` を要求。
  - `tests/pages/panel-scrollbar-padding.test.ts`: main の `px-4` を禁止、スクロール領域の `pr-1` を担保。
  - `tests/styles/main-css-cleanup.test.ts`: `body` の `overflow-x: hidden` と `html/body` の `margin/padding: 0` を検査。

## 背景 / 目的
- ヘッダー行が `whitespace-nowrap` を用いるため、内側コンテナで横オーバーフローが発生していました。
- サイドパネルの UI 方針を壊さず、横スクロールをグローバルに抑止する必要がありました。

## 動作確認
1. `npm ci && npm test` ですべて緑になること（ローカルで 193/193 パス）。
2. 拡張を再読み込みしてサイドパネルを最小近辺まで縮める。
3. 横スクロールが発生しないことを確認。
4. モーダル/トースト表示時にも横スクロールが出ないことを確認。

## リスクと互換性
- Main content の左右パディングを削除したため、極端に狭い幅での端寄せ感が増しますが、`my-2` やカードの余白で視認性は保たれます。
- 既存の UI ルール（ヘッダー nowrap、バッジの省幅化）は維持しています。

## スクリーンショット（任意）
- 必要であれば追って添付します。
