### PR TITLE
Fix markdown export missing task title

### DIFF
--- a/src/panel-client.ts
+++ b/src/panel-client.ts
@@ -468,12 +468,14 @@ class PetaTasClient {
     try {
       if (this.currentTasks.length === 0) return
       if (!navigator.clipboard?.writeText) throw new Error('Clipboard API not available')
+      const baseHeaders = ['Task']
       const extensionHeaders = ['Status', 'Notes', 'Timer']
       const custom = new Set<string>()
       this.currentTasks.forEach(t => Object.keys(t.additionalColumns || {}).forEach(h => custom.add(h)))
-      const headers = [...extensionHeaders, ...Array.from(custom)]
+      const headers = [...baseHeaders, ...extensionHeaders, ...Array.from(custom)]
       const rows = this.currentTasks.map((t) => headers.map((h) => {
         switch (h) {
+          case 'Task': return t.name
           case 'Status': return t.status
           case 'Notes': return t.notes
           case 'Timer': return this.formatTime(t.elapsedMs)

--- a/tests/features/export-toast-and-menu-close.test.ts
+++ b/tests/features/export-toast-and-menu-close.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
 import { JSDOM } from 'jsdom'
 
 // Minimal Task shape used by storage mock
@@ -88,6 +88,11 @@ describe('Export shows toast and closes menu', () => {
 
     // Allow async export
     await new Promise(r => setTimeout(r, 10))
+
+    const markdown = (navigator.clipboard.writeText as unknown as Mock).mock.calls[0][0] as string
+
+    expect(markdown).toContain('| Task | Status | Notes | Timer | Priority |')
+    expect(markdown).toContain('| A | todo |  | 00:00:00 | High |')
 
     // Success toast appears
     const toast = document.querySelector('#toast-container .alert.alert-success') as HTMLElement | null


### PR DESCRIPTION
## Summary
- ensure the markdown export always includes the Task column header
- map each row's Task value to the task name so the clipboard payload matches expectations
- cover the regression with an end-to-end style feature test that inspects the exported markdown string

## Testing
- npm test
