### PR TITLE
Ensure prefixed timer tokens return zero

### DIFF
--- a/src/utils/time-utils.ts
+++ b/src/utils/time-utils.ts
@@ -7,7 +7,7 @@ export function parseTimerToMs(input: string): number {
   const s = input.trim();
 
   // Token format: 1h 2m 3s
-  const tokenRe = /(?:(\d+)\s*h)?\s*(?:(\d+)\s*m)?\s*(?:(\d+)\s*s)?$/i;
+  const tokenRe = /^(?:(\d+)\s*h)?\s*(?:(\d+)\s*m)?\s*(?:(\d+)\s*s)?$/i;
   const tokenMatch = s.match(tokenRe);
   if (tokenMatch && (tokenMatch[1] || tokenMatch[2] || tokenMatch[3])) {
     const h = parseInt(tokenMatch[1] || '0', 10);

--- a/tests/background/service-worker.test.ts
+++ b/tests/background/service-worker.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('service-worker integration', () => {
+  let eventListeners: Record<string, (event: unknown) => void>;
+  let actionListeners: Array<(tab: chrome.tabs.Tab) => Promise<void> | void>;
+  let connectListeners: Array<(port: chrome.runtime.Port) => void>;
+  let storageListeners: Array<(changes: Record<string, unknown>, namespace: string) => void>;
+  let openSpy: ReturnType<typeof vi.fn>;
+  let skipWaitingSpy: ReturnType<typeof vi.fn>;
+  let claimSpy: ReturnType<typeof vi.fn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    eventListeners = {};
+    actionListeners = [];
+    connectListeners = [];
+    storageListeners = [];
+    skipWaitingSpy = vi.fn();
+    claimSpy = vi.fn().mockResolvedValue(undefined);
+
+    (globalThis as typeof globalThis & { self: ServiceWorkerGlobalScope }).self = {
+      addEventListener: vi.fn((event: string, handler: (evt: unknown) => void) => {
+        eventListeners[event] = handler;
+      }),
+      skipWaiting: skipWaitingSpy,
+      clients: { claim: claimSpy },
+    } as unknown as ServiceWorkerGlobalScope;
+
+    openSpy = vi.fn().mockResolvedValue(undefined);
+
+    (globalThis as typeof globalThis & { chrome: typeof chrome }).chrome = {
+      action: {
+        onClicked: {
+          addListener: (listener: (tab: chrome.tabs.Tab) => void) => {
+            actionListeners.push(listener);
+          },
+        },
+      },
+      sidePanel: {
+        open: openSpy,
+      },
+      runtime: {
+        onConnect: {
+          addListener: (listener: (port: chrome.runtime.Port) => void) => {
+            connectListeners.push(listener);
+          },
+        },
+      },
+      storage: {
+        onChanged: {
+          addListener: (listener: (changes: Record<string, unknown>, namespace: string) => void) => {
+            storageListeners.push(listener);
+          },
+        },
+      },
+    } as unknown as typeof chrome;
+
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await import('@/service-worker');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (globalThis as typeof globalThis & { self?: ServiceWorkerGlobalScope }).self;
+    delete (globalThis as typeof globalThis & { chrome?: typeof chrome }).chrome;
+  });
+
+  it('opens side panel when toolbar icon clicked', async () => {
+    const listener = actionListeners[0];
+    expect(listener).toBeDefined();
+    await listener?.({ id: 123 } as chrome.tabs.Tab);
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenLastCalledWith({ tabId: 123 });
+  });
+
+  it('ignores toolbar clicks that lack a tab id', async () => {
+    const listener = actionListeners[0];
+    expect(listener).toBeDefined();
+    await listener?.({} as chrome.tabs.Tab);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('installs and keeps the worker waiting', () => {
+    const installHandler = eventListeners.install;
+    expect(installHandler).toBeDefined();
+    installHandler?.({} as Event);
+    expect(skipWaitingSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('activates and claims open clients', async () => {
+    const activateHandler = eventListeners.activate;
+    expect(activateHandler).toBeDefined();
+    const waitUntil = vi.fn();
+    activateHandler?.({ waitUntil } as unknown as ExtendableEvent);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    const [activationPromise] = waitUntil.mock.calls[0];
+    expect(activationPromise).toBeInstanceOf(Promise);
+    await activationPromise;
+    expect(claimSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('responds to ping messages from the panel port', () => {
+    const connectListener = connectListeners[0];
+    expect(connectListener).toBeDefined();
+
+    const messageListeners: Array<(message: { type: string; taskId?: string }) => void> = [];
+    const disconnectListeners: Array<() => void> = [];
+    const postMessage = vi.fn();
+
+    connectListener?.({
+      name: 'panel',
+      postMessage,
+      onMessage: { addListener: (cb: (message: { type: string }) => void) => messageListeners.push(cb) },
+      onDisconnect: { addListener: (cb: () => void) => disconnectListeners.push(cb) },
+    } as unknown as chrome.runtime.Port);
+
+    expect(messageListeners).toHaveLength(1);
+    messageListeners[0]?.({ type: 'PING' });
+    expect(postMessage).toHaveBeenCalledWith({ type: 'PONG' });
+  });
+
+  it('logs timer updates, unknown messages, and disconnects', () => {
+    const connectListener = connectListeners[0];
+    expect(connectListener).toBeDefined();
+
+    const messageListeners: Array<(message: { type: string; taskId?: string }) => void> = [];
+    const disconnectListeners: Array<() => void> = [];
+
+    connectListener?.({
+      name: 'panel',
+      postMessage: vi.fn(),
+      onMessage: { addListener: (cb: (message: { type: string; taskId?: string }) => void) => messageListeners.push(cb) },
+      onDisconnect: { addListener: (cb: () => void) => disconnectListeners.push(cb) },
+    } as unknown as chrome.runtime.Port);
+
+    messageListeners[0]?.({ type: 'TIMER_START', taskId: 'task-1' });
+    messageListeners[0]?.({ type: 'TIMER_STOP', taskId: 'task-1' });
+    messageListeners[0]?.({ type: 'WHAT' });
+    disconnectListeners[0]?.();
+
+    expect(logSpy).toHaveBeenCalledWith('Side panel connected');
+    expect(logSpy).toHaveBeenCalledWith('Timer started for task:', 'task-1');
+    expect(logSpy).toHaveBeenCalledWith('Timer stopped for task:', 'task-1');
+    expect(logSpy).toHaveBeenCalledWith('Unknown message type:', 'WHAT');
+    expect(logSpy).toHaveBeenCalledWith('Side panel disconnected');
+  });
+
+  it('logs storage changes for debugging', () => {
+    const storageListener = storageListeners[0];
+    expect(storageListener).toBeDefined();
+    storageListener?.({ tasks: { newValue: 1 } }, 'sync');
+    expect(logSpy).toHaveBeenCalledWith('Storage changed:', 'sync', { tasks: { newValue: 1 } });
+  });
+
+  it('ignores ports that are not the side panel', () => {
+    const connectListener = connectListeners[0];
+    expect(connectListener).toBeDefined();
+
+    connectListener?.({
+      name: 'popup',
+      postMessage: vi.fn(),
+      onMessage: { addListener: vi.fn() },
+      onDisconnect: { addListener: vi.fn() },
+    } as unknown as chrome.runtime.Port);
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/features/paste-and-clear-errors.test.ts
+++ b/tests/features/paste-and-clear-errors.test.ts
@@ -1,0 +1,323 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+
+const parseMarkdownTableMock = vi.fn()
+const loadNormalizedTitleAliasesMock = vi.fn<[], Promise<Set<string>>>()
+const loadTitleAliasesMock = vi.fn<[], Promise<string[]>>()
+const parseCsvAliasesMock = vi.fn<[string], string[]>()
+const saveTitleAliasesMock = vi.fn<[string[]], Promise<void>>()
+
+const handleClipboardErrorMock = vi.fn()
+const handleGeneralErrorMock = vi.fn()
+const handleStorageErrorMock = vi.fn()
+const showToastMock = vi.fn()
+
+const storageLoadMock = vi.fn<[], Promise<any[]>>()
+const storageSaveMock = vi.fn<[any[]], Promise<void>>()
+const storageClearTimerStateMock = vi.fn<[string], Promise<void>>()
+const storageClearTimerStatesMock = vi.fn<[], Promise<void>>()
+
+class FakeTimerUI {
+  static instances: FakeTimerUI[] = []
+
+  readonly isRunning = vi.fn().mockReturnValue(false)
+  readonly toggle = vi.fn()
+  readonly clearAll = vi.fn()
+  readonly setBaseElapsedMs = vi.fn()
+
+  constructor(private readonly opts: unknown) {
+    FakeTimerUI.instances.push(this)
+    void this.opts
+  }
+
+  static reset(): void {
+    FakeTimerUI.instances.length = 0
+  }
+}
+
+vi.mock('@/utils/markdown-parser', () => ({
+  parseMarkdownTable: parseMarkdownTableMock,
+}))
+
+vi.mock('@/utils/settings-manager', () => ({
+  loadNormalizedTitleAliases: loadNormalizedTitleAliasesMock,
+  loadTitleAliases: loadTitleAliasesMock,
+  parseCsvAliases: parseCsvAliasesMock,
+  saveTitleAliases: saveTitleAliasesMock,
+}))
+
+vi.mock('@/utils/error-handler', () => ({
+  handleClipboardError: handleClipboardErrorMock,
+  handleGeneralError: handleGeneralErrorMock,
+  handleStorageError: handleStorageErrorMock,
+}))
+
+vi.mock('@/utils/storage-manager', () => ({
+  StorageManager: class {
+    loadTasks = storageLoadMock
+    saveTasks = storageSaveMock
+    clearTimerState = storageClearTimerStateMock
+    clearTimerStates = storageClearTimerStatesMock
+  }
+}))
+
+vi.mock('@/utils/timer-ui', () => ({
+  default: FakeTimerUI,
+}))
+
+vi.mock('@/utils/theme', () => ({
+  initSystemThemeSync: vi.fn(),
+}))
+
+vi.mock('@/utils/toast', () => ({
+  default: showToastMock,
+}))
+
+vi.mock('@/utils/time-utils', () => ({
+  minutesToMs: (minutes: number) => minutes * 60 * 1000,
+  formatHms: (ms: number) => `00:00:${String(Math.floor(ms / 1000)).padStart(2, '0')}`,
+}))
+
+vi.mock('@/utils/task-renderer', () => ({
+  default: vi.fn(() => '<li data-testid="task-row"></li>'),
+}))
+
+vi.mock('@/utils/task-dom', () => ({
+  applyRowVisualState: vi.fn(),
+  updateRowFromTask: vi.fn(),
+  setTimerButtonState: vi.fn(),
+}))
+
+vi.mock('@/types/task', () => ({
+  createTask: vi.fn(() => ({
+    id: 'generated-task',
+    name: 'Generated',
+    status: 'todo',
+    notes: '',
+    elapsedMs: 0,
+    additionalColumns: {},
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+  })),
+}))
+
+vi.mock('@/utils/system-columns', () => ({
+  isSystemHeader: vi.fn(() => false),
+}))
+
+const flushAsync = async () => {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+const originalNavigator = globalThis.navigator
+
+describe('PetaTasClient paste & clear flows', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    FakeTimerUI.reset()
+
+    const clipboard = {
+      readText: vi.fn(),
+      writeText: vi.fn(),
+    }
+
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: { clipboard },
+    })
+
+    ;(globalThis as any).chrome = { storage: { sync: {} } }
+
+    document.body.innerHTML = `
+      <button id="paste-button"></button>
+      <button id="export-button"></button>
+      <div class="dropdown"></div>
+      <button id="add-task-button"></button>
+      <button id="clear-all-button"></button>
+      <button id="settings-button"></button>
+      <form id="settings-form"></form>
+      <input id="settings-modal" type="checkbox" />
+      <form id="add-task-form"></form>
+      <div id="dynamic-fields-container"></div>
+      <div id="task-list"></div>
+      <div id="empty-state"></div>
+    `
+
+    storageSaveMock.mockResolvedValue(undefined)
+    storageClearTimerStateMock.mockResolvedValue(undefined)
+    storageClearTimerStatesMock.mockResolvedValue(undefined)
+    loadNormalizedTitleAliasesMock.mockResolvedValue(new Set())
+    loadTitleAliasesMock.mockResolvedValue([])
+    parseCsvAliasesMock.mockImplementation((raw: string) => raw.split(',').map(s => s.trim()).filter(Boolean))
+    saveTitleAliasesMock.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: originalNavigator,
+    })
+    delete (globalThis as any).chrome
+    delete (globalThis as any).confirm
+  })
+
+  it('aborts paste when user cancels confirmation', async () => {
+    storageLoadMock.mockResolvedValue([
+      {
+        id: 'existing',
+        name: 'Existing',
+        status: 'todo',
+        notes: '',
+        elapsedMs: 0,
+        additionalColumns: {},
+        createdAt: new Date('2023-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2023-01-01T00:00:00.000Z'),
+      }
+    ])
+
+    parseMarkdownTableMock.mockReturnValue({
+      headers: ['Task'],
+      rows: [['Task from clipboard']],
+    })
+
+    const clipboard = globalThis.navigator.clipboard as { readText: ReturnType<typeof vi.fn> }
+    clipboard.readText.mockResolvedValue('| Task |\n| --- |\n| Task from clipboard |')
+
+    ;(globalThis as any).confirm = vi.fn(() => false)
+
+    await import('@/panel-client')
+    await flushAsync()
+
+    document.getElementById('paste-button')?.dispatchEvent(new Event('click'))
+    await flushAsync()
+
+    expect(globalThis.navigator.clipboard.readText).toHaveBeenCalled()
+    expect(parseMarkdownTableMock).toHaveBeenCalled()
+    expect(globalThis.confirm).toHaveBeenCalledTimes(1)
+    expect(loadNormalizedTitleAliasesMock).not.toHaveBeenCalled()
+    expect(FakeTimerUI.instances[0]?.clearAll).not.toHaveBeenCalled()
+    expect(showToastMock).not.toHaveBeenCalledWith(expect.stringContaining('Imported'), 'success')
+    expect(handleClipboardErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('reports clipboard read failures', async () => {
+    storageLoadMock.mockResolvedValue([])
+
+    const clipboard = globalThis.navigator.clipboard as { readText: ReturnType<typeof vi.fn> }
+    clipboard.readText.mockRejectedValue(new Error('denied'))
+
+    await import('@/panel-client')
+    await flushAsync()
+
+    document.getElementById('paste-button')?.dispatchEvent(new Event('click'))
+    await flushAsync()
+
+    expect(handleClipboardErrorMock).toHaveBeenCalledWith(expect.any(Error), { module: 'PetaTasClient', operation: 'handlePasteClick' }, 'read')
+  })
+
+  it('handles errors when clearing all tasks fails', async () => {
+    storageLoadMock.mockResolvedValue([
+      {
+        id: 'existing',
+        name: 'Existing',
+        status: 'todo',
+        notes: '',
+        elapsedMs: 0,
+        additionalColumns: {},
+        createdAt: new Date('2023-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2023-01-01T00:00:00.000Z'),
+      }
+    ])
+
+    storageClearTimerStatesMock.mockRejectedValueOnce(new Error('clear failed'))
+
+    ;(globalThis as any).confirm = vi.fn(() => true)
+
+    await import('@/panel-client')
+    await flushAsync()
+
+    document.getElementById('clear-all-button')?.dispatchEvent(new Event('click'))
+    await flushAsync()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await flushAsync()
+
+    expect(FakeTimerUI.instances[0]?.clearAll).toHaveBeenCalled()
+    expect(storageClearTimerStatesMock).toHaveBeenCalled()
+    expect(storageSaveMock).toHaveBeenCalled()
+    expect(handleGeneralErrorMock).toHaveBeenCalledWith(expect.any(Error), 'high', { module: 'PetaTasClient', operation: 'clearAllTasks' })
+  })
+  it('clears all tasks when confirm is unavailable', async () => {
+    storageLoadMock.mockResolvedValue([
+      {
+        id: 'existing',
+        name: 'Existing',
+        status: 'todo',
+        notes: '',
+        elapsedMs: 0,
+        additionalColumns: {},
+        createdAt: new Date('2023-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2023-01-01T00:00:00.000Z'),
+      }
+    ])
+
+    Object.defineProperty(globalThis, 'confirm', { configurable: true, value: undefined })
+
+    await import('@/panel-client')
+    await flushAsync()
+
+    const clearButton = document.getElementById('clear-all-button')
+    clearButton?.dispatchEvent(new Event('click'))
+
+    await flushAsync()
+    await flushAsync()
+
+    const timerInstance = FakeTimerUI.instances[0]
+    expect(timerInstance?.clearAll).toHaveBeenCalled()
+    expect(storageClearTimerStatesMock).toHaveBeenCalledTimes(1)
+    expect(storageSaveMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops running timer and logs when storage cleanup fails during deletion', async () => {
+    storageLoadMock.mockResolvedValue([
+      {
+        id: 'task-1',
+        name: 'Del Target',
+        status: 'todo',
+        notes: '',
+        elapsedMs: 120000,
+        additionalColumns: {},
+        createdAt: new Date('2023-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2023-01-01T00:00:00.000Z'),
+      }
+    ])
+
+    storageClearTimerStateMock.mockRejectedValue(new Error('Storage error'))
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await import('@/panel-client')
+    await flushAsync()
+
+    const timerInstance = FakeTimerUI.instances[0]
+    timerInstance?.isRunning.mockReturnValue(true)
+
+    const list = document.getElementById('task-list')
+    list!.innerHTML = '<button data-action="delete" data-task-id="task-1"></button>'
+
+    const deleteBtn = list?.querySelector('[data-action="delete"]') as HTMLButtonElement | null
+    deleteBtn?.dispatchEvent(new Event('click', { bubbles: true }))
+
+    await flushAsync()
+    await flushAsync()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(timerInstance?.toggle).toHaveBeenCalledWith('task-1')
+    expect(storageSaveMock).toHaveBeenCalled()
+    expect(storageClearTimerStateMock).toHaveBeenCalledWith('task-1')
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to clean up task data:', expect.any(Error))
+
+    consoleErrorSpy.mockRestore()
+  })
+
+})

--- a/tests/features/settings-errors.test.ts
+++ b/tests/features/settings-errors.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+
+const loadTitleAliasesMock = vi.fn<[], Promise<string[]>>()
+const saveTitleAliasesMock = vi.fn<[string[]], Promise<void>>()
+const parseCsvAliasesMock = vi.fn<[string], string[]>()
+const loadNormalizedTitleAliasesMock = vi.fn<[], Promise<Set<string>>>()
+
+const handleGeneralErrorMock = vi.fn()
+const handleClipboardErrorMock = vi.fn()
+const handleStorageErrorMock = vi.fn()
+const handleClipboardReadMock = vi.fn()
+const showToastMock = vi.fn()
+
+const storageLoadMock = vi.fn<[], Promise<any[]>>()
+const storageSaveMock = vi.fn<[any[]], Promise<void>>()
+const storageClearTimerStateMock = vi.fn<[string], Promise<void>>()
+const storageClearTimerStatesMock = vi.fn<[], Promise<void>>()
+
+class FakeTimerUI {
+  isRunning = vi.fn().mockReturnValue(false)
+  toggle = vi.fn()
+  clearAll = vi.fn()
+  setBaseElapsedMs = vi.fn()
+
+  constructor(private readonly opts: unknown) {
+    void this.opts
+  }
+}
+
+vi.mock('@/utils/settings-manager', () => ({
+  loadNormalizedTitleAliases: loadNormalizedTitleAliasesMock,
+  loadTitleAliases: loadTitleAliasesMock,
+  parseCsvAliases: parseCsvAliasesMock,
+  saveTitleAliases: saveTitleAliasesMock,
+}))
+
+vi.mock('@/utils/error-handler', () => ({
+  handleStorageError: handleStorageErrorMock,
+  handleClipboardError: handleClipboardErrorMock,
+  handleGeneralError: handleGeneralErrorMock,
+  handleClipboardErrorForTests: handleClipboardReadMock,
+}))
+
+vi.mock('@/utils/storage-manager', () => ({
+  StorageManager: class {
+    loadTasks = storageLoadMock
+    saveTasks = storageSaveMock
+    clearTimerState = storageClearTimerStateMock
+    clearTimerStates = storageClearTimerStatesMock
+  }
+}))
+
+vi.mock('@/utils/timer-ui', () => ({
+  default: FakeTimerUI,
+}))
+
+vi.mock('@/utils/theme', () => ({
+  initSystemThemeSync: vi.fn(),
+}))
+
+vi.mock('@/utils/toast', () => ({
+  default: showToastMock,
+}))
+
+vi.mock('@/utils/markdown-parser', () => ({
+  parseMarkdownTable: vi.fn(),
+}))
+
+vi.mock('@/utils/time-utils', () => ({
+  minutesToMs: (n: number) => n * 60000,
+  formatHms: (ms: number) => `00:00:${String(Math.floor(ms / 1000)).padStart(2, '0')}`,
+}))
+
+vi.mock('@/utils/task-renderer', () => ({
+  default: vi.fn(() => '<div data-testid="task-row"></div>'),
+}))
+
+vi.mock('@/utils/task-dom', () => ({
+  applyRowVisualState: vi.fn(),
+  updateRowFromTask: vi.fn(),
+  setTimerButtonState: vi.fn(),
+}))
+
+vi.mock('@/utils/form-field-utils', () => ({
+  getFieldLabel: (name: string) => name,
+  getFieldPlaceholder: (name: string) => `Enter ${name}`,
+}))
+
+vi.mock('@/utils/form-state-utils', () => ({
+  captureDynamicFieldState: vi.fn(() => ({ inputs: [] })),
+  restoreDynamicFieldState: vi.fn(),
+}))
+
+vi.mock('@/types/task', () => ({
+  createTask: vi.fn(() => ({
+    id: 'generated',
+    name: 'Generated Task',
+    status: 'todo',
+    notes: '',
+    elapsedMs: 0,
+    additionalColumns: {},
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    updatedAt: new Date('2024-01-01T00:00:00Z'),
+  })),
+  Task: class {},
+}))
+
+vi.mock('@/utils/system-columns', () => ({
+  isSystemHeader: vi.fn(() => false),
+}))
+
+const flushAsync = async () => {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('PetaTasClient settings error handling', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    storageLoadMock.mockResolvedValue([])
+    storageSaveMock.mockResolvedValue()
+    storageClearTimerStateMock.mockResolvedValue()
+    storageClearTimerStatesMock.mockResolvedValue()
+    loadNormalizedTitleAliasesMock.mockResolvedValue(new Set())
+    loadTitleAliasesMock.mockResolvedValue([])
+    parseCsvAliasesMock.mockImplementation((raw: string) => raw.split(',').map(s => s.trim()).filter(Boolean))
+    saveTitleAliasesMock.mockResolvedValue()
+
+    document.body.innerHTML = `
+      <button id="settings-button">settings</button>
+      <form id="settings-form">
+        <textarea id="title-aliases-input"></textarea>
+      </form>
+      <input id="settings-modal" type="checkbox" />
+      <div id="task-list"></div>
+      <div id="empty-state"></div>
+    `
+
+    ;(globalThis as any).chrome = { storage: { sync: {} } }
+    ;(globalThis as any).confirm = vi.fn(() => true)
+  })
+
+  afterEach(() => {
+    delete (globalThis as any).chrome
+    delete (globalThis as any).confirm
+  })
+
+  it('reports a load error when opening settings fails', async () => {
+    loadTitleAliasesMock.mockRejectedValueOnce(new Error('load failed'))
+
+    await import('@/panel-client')
+    await flushAsync()
+
+    document.getElementById('settings-button')?.dispatchEvent(new Event('click'))
+
+    await flushAsync()
+
+    expect(handleGeneralErrorMock).toHaveBeenCalledWith(expect.any(Error), 'medium', { module: 'PetaTasClient', operation: 'openSettings' })
+  })
+
+  it('shows toast and logs when saving settings fails', async () => {
+    saveTitleAliasesMock.mockRejectedValueOnce(new Error('persist failed'))
+
+    await import('@/panel-client')
+    await flushAsync()
+
+    const textarea = document.getElementById('title-aliases-input') as HTMLTextAreaElement
+    textarea.value = 'alias1'
+
+    const form = document.getElementById('settings-form') as HTMLFormElement
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+
+    await flushAsync()
+
+    expect(saveTitleAliasesMock).toHaveBeenCalledWith(['alias1'])
+
+    expect(handleGeneralErrorMock).toHaveBeenCalledWith(expect.any(Error), 'high', { module: 'PetaTasClient', operation: 'saveSettings' })
+    expect(showToastMock).toHaveBeenCalledWith('Failed to save settings.', 'error')
+  })
+})

--- a/tests/utils/error-handler.test.ts
+++ b/tests/utils/error-handler.test.ts
@@ -54,6 +54,22 @@ describe('ErrorHandler', () => {
     });
   });
 
+    it('should dispatch error-notification events with provided user message', () => {
+      const context = { module: 'ui', operation: 'showToast' };
+      const listener = vi.fn<(event: Event) => void>();
+      document.addEventListener('error-notification', listener);
+
+      errorHandler.handleError(new Error('Notify'), 'high', context, 'Display this');
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      const evt = listener.mock.calls[0][0] as CustomEvent<{ message?: string; severity?: string; timestamp: number }>;
+      expect(evt.detail.message).toBe('Display this');
+      expect(evt.detail.severity).toBe('high');
+      expect(evt.detail.timestamp).toBeInstanceOf(Date);
+
+      document.removeEventListener('error-notification', listener);
+    });
+
   describe('handleStorageError', () => {
     it('should handle throttling errors with low severity', () => {
       const context = { module: 'storage', operation: 'save' };

--- a/tests/utils/storage-manager-throttle.test.ts
+++ b/tests/utils/storage-manager-throttle.test.ts
@@ -4,8 +4,6 @@ import type { Task } from '@/types/task'
 
 describe('StorageManager throttle injection', () => {
   beforeEach(() => {
-    vi.useFakeTimers()
-    // Minimal chrome mock
     const tasks: Task[] = []
     const mockChrome = {
       storage: {
@@ -37,6 +35,7 @@ describe('StorageManager throttle injection', () => {
   })
 
   it('delays writes according to provided writeThrottleMs', async () => {
+    vi.useFakeTimers()
     const sm = new StorageManager({ writeThrottleMs: 20 })
 
     const task: Task = {
@@ -45,14 +44,79 @@ describe('StorageManager throttle injection', () => {
     }
 
     const p = sm.saveTasks([task])
-    // Not yet called before throttle delay elapses
     expect(chrome.storage.sync.set).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(19)
     expect(chrome.storage.sync.set).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(2)
-    await p // resolve after batch write executes
+    await p
     expect(chrome.storage.sync.set).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects superseded writes for the same key', async () => {
+    vi.useFakeTimers()
+    const sm = new StorageManager({ writeThrottleMs: 10 })
+
+    const first = sm.saveTimerState({ taskId: 'task-1', isRunning: false, startTime: 0, elapsedMs: 0 })
+    const second = sm.saveTimerState({ taskId: 'task-1', isRunning: true, startTime: 1000, elapsedMs: 5000 })
+
+    await expect(first).rejects.toThrow('Write operation replaced by newer write')
+
+    await vi.advanceTimersByTimeAsync(11)
+    await expect(second).resolves.toBeUndefined()
+
+    const setMock = chrome.storage.sync.set as ReturnType<typeof vi.fn>
+    expect(setMock).toHaveBeenCalledTimes(1)
+    expect(setMock.mock.calls[0][0]).toEqual({
+      'timer_task-1': { taskId: 'task-1', isRunning: true, startTime: 1000, elapsedMs: 5000 }
+    })
+  })
+
+  it('defers batch writes when approaching rate limits', async () => {
+    vi.useFakeTimers()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.setSystemTime(new Date('2025-01-01T00:00:00.000Z'))
+
+    const sm = new StorageManager({ writeThrottleMs: 10, maxWritesPerMinute: 2 })
+    ;(sm as unknown as { writeHistory: number[] }).writeHistory = [Date.now() - 1000, Date.now() - 2000]
+
+    const pending = sm.saveTimerState({ taskId: 'limit', isRunning: false, startTime: 0, elapsedMs: 0 })
+
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(warnSpy).toHaveBeenCalledWith('Approaching write rate limit, delaying writes')
+    expect(chrome.storage.sync.set).not.toHaveBeenCalled()
+
+    warnSpy.mockClear()
+    ;(sm as unknown as { writeHistory: number[] }).writeHistory = []
+    await vi.advanceTimersByTimeAsync(11)
+    await pending
+
+    warnSpy.mockRestore()
+  })
+
+  it('propagates quota errors and logs diagnostics', async () => {
+    vi.useFakeTimers()
+    const setMock = chrome.storage.sync.set as ReturnType<typeof vi.fn>
+    setMock.mockRejectedValueOnce(new Error('MAX_WRITE_OPERATIONS_PER_MINUTE reached'))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const sm = new StorageManager({ writeThrottleMs: 10 })
+    const promise = sm.saveTimerState({ taskId: 'quota', isRunning: false, startTime: 0, elapsedMs: 0 }).catch(error => error)
+
+    await vi.advanceTimersByTimeAsync(11)
+
+    const result = await promise
+    expect(result).toBeInstanceOf(Error)
+    expect((result as Error).message).toContain('MAX_WRITE_OPERATIONS_PER_MINUTE reached')
+    expect(errorSpy).toHaveBeenCalledWith('Batch write failed:', expect.any(Error))
+    expect(warnSpy).toHaveBeenCalledWith('Storage quota exceeded, increasing throttle delay')
+
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+    setMock.mockResolvedValue(undefined)
+    await vi.advanceTimersByTimeAsync(30)
   })
 })

--- a/tests/utils/time-utils.test.ts
+++ b/tests/utils/time-utils.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatHms, minutesToMs, msToMinutes, parseTimerToMs } from '@/utils/time-utils';
+
+describe('parseTimerToMs', () => {
+  it('parses colon format with hours', () => {
+    expect(parseTimerToMs('02:03:04')).toBe(2 * 3600 * 1000 + 3 * 60 * 1000 + 4 * 1000);
+  });
+
+  it('parses minute-second format', () => {
+    expect(parseTimerToMs('15:30')).toBe((15 * 60 + 30) * 1000);
+  });
+
+  it('returns zero when seconds segment is negative', () => {
+    expect(parseTimerToMs('05:-30')).toBe(0);
+  });
+
+  it('parses seconds-only token format', () => {
+    expect(parseTimerToMs('45s')).toBe(45 * 1000);
+  });
+
+  it('returns zero for whitespace-only input', () => {
+    expect(parseTimerToMs('   ')).toBe(0);
+  });
+
+  it('parses token-based format', () => {
+    expect(parseTimerToMs('1h 5m 30s')).toBe(((1 * 60 + 5) * 60 + 30) * 1000);
+  });
+
+  it('rejects strings with non-time prefixes', () => {
+    expect(parseTimerToMs('draft 1h 5m')).toBe(0);
+  });
+});
+
+describe('formatHms', () => {
+  it('pads each unit to two digits', () => {
+    expect(formatHms(5 * 1000)).toBe('00:00:05');
+    expect(formatHms(65 * 1000)).toBe('00:01:05');
+  });
+});
+
+describe('minutesToMs', () => {
+  it('clamps negative values to zero', () => {
+    expect(minutesToMs(-5)).toBe(0);
+    expect(minutesToMs(2)).toBe(2 * 60 * 1000);
+  });
+});
+
+describe('msToMinutes', () => {
+  it('rounds to the nearest minute', () => {
+    expect(msToMinutes(90_000)).toBe(2);
+  });
+});

--- a/tests/utils/timer-ui.test.ts
+++ b/tests/utils/timer-ui.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import TimerUI from '@/utils/timer-ui'
+
+const createBaseTask = () => ({
+  id: 'task-1',
+  title: 'Test task',
+  status: 'todo' as const,
+  elapsedMs: 0,
+  createdAt: new Date('2024-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2024-01-01T00:00:00.000Z')
+})
+
+describe('TimerUI', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  const createTimerUI = () => {
+    const tasks = [createBaseTask()]
+    const getTasks = () => tasks
+    const saveTasks = vi.fn(async () => {})
+    const updateTaskRowVisualState = vi.fn()
+    const updateTimerButtonState = vi.fn()
+
+    const timerUI = new TimerUI({
+      getTasks,
+      saveTasks,
+      updateTaskRowVisualState,
+      updateTimerButtonState
+    })
+
+    return { tasks, timerUI, saveTasks, updateTaskRowVisualState, updateTimerButtonState }
+  }
+
+  it('starts a timer for todo tasks and updates UI state', () => {
+    const { timerUI, updateTaskRowVisualState, updateTimerButtonState, saveTasks, tasks } = createTimerUI()
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'))
+
+    timerUI.toggle('task-1')
+
+    expect(timerUI.isRunning('task-1')).toBe(true)
+    expect(tasks[0].status).toBe('in-progress')
+    expect(updateTaskRowVisualState).toHaveBeenCalledWith('task-1', 'in-progress')
+    expect(updateTimerButtonState).toHaveBeenCalledWith('task-1', true)
+    expect(saveTasks).toHaveBeenCalled()
+  })
+
+  it('does not restart a completed task timer', () => {
+    const { timerUI, updateTimerButtonState, tasks } = createTimerUI()
+    tasks[0].status = 'done'
+
+    timerUI.toggle('task-1')
+
+    expect(timerUI.isRunning('task-1')).toBe(false)
+    expect(updateTimerButtonState).toHaveBeenCalledWith('task-1', false)
+  })
+
+  it('stops a running timer, persists state, and restores task status', async () => {
+    const { timerUI, updateTaskRowVisualState, updateTimerButtonState, saveTasks, tasks } = createTimerUI()
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'))
+    timerUI.toggle('task-1')
+    expect(timerUI.isRunning('task-1')).toBe(true)
+
+    vi.setSystemTime(new Date('2024-01-01T00:00:02.000Z'))
+    timerUI.toggle('task-1')
+
+    expect(timerUI.isRunning('task-1')).toBe(false)
+    expect(tasks[0].elapsedMs).toBe(2000)
+    expect(updateTaskRowVisualState).toHaveBeenCalledWith('task-1', 'todo')
+    expect(updateTimerButtonState).toHaveBeenLastCalledWith('task-1', false)
+    expect(saveTasks).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-bases elapsed ms while timer continues running', () => {
+    const { timerUI, tasks } = createTimerUI()
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'))
+    timerUI.toggle('task-1')
+    vi.setSystemTime(new Date('2024-01-01T00:00:03.000Z'))
+
+    timerUI.setBaseElapsedMs('task-1', 60000)
+    vi.setSystemTime(new Date('2024-01-01T00:00:05.000Z'))
+    timerUI.toggle('task-1')
+
+    expect(tasks[0].elapsedMs).toBe(62000)
+  })
+
+  it('applies batched DOM updates with formatted time', () => {
+    const { timerUI } = createTimerUI()
+    document.body.innerHTML = '<div data-testid="task-task-1"><span class="timer-display">--:--</span></div>'
+
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'))
+    timerUI.toggle('task-1')
+    vi.setSystemTime(new Date('2024-01-01T00:00:07.000Z'))
+
+    ;(timerUI as unknown as { scheduleUpdate: (id: string) => void }).scheduleUpdate('task-1')
+    vi.advanceTimersByTime(100)
+
+    const display = document.querySelector('[data-testid="task-task-1"] .timer-display')
+    expect(display?.textContent).toBe('00:00:07')
+
+    timerUI.clearAll()
+  })
+
+  it('clears all running timers', () => {
+    const { timerUI } = createTimerUI()
+    timerUI.toggle('task-1')
+
+    timerUI.clearAll()
+
+    expect(timerUI.isRunning('task-1')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- constrain token-based timer parsing to reject prefixed noise
- add expanded timer/storage/service worker coverage for regression shielding

## Testing
- npm run test