### PR TITLE
Update README build and workflow guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,22 @@ Markdown table-based task management with timers and side panel functionality.
 
 ## Installation & Testing
 
-### 1. Load Extension in Chrome Developer Mode
+### 1. Build the Extension
+
+1. `npm install`
+2. `npm run build`
+   - The production bundle is emitted to `dist/`
+
+### 2. Load Extension in Chrome Developer Mode
 
 1. Open Chrome browser
 2. Navigate to `chrome://extensions/`
 3. Enable "Developer mode" (toggle in top right)
 4. Click "Load unpacked"
-5. Select the `dist` folder from this directory
+5. Select the `dist` folder generated in the previous step
 6. The extension should now appear in your extensions list
 
-### 2. Usage
+### 3. Usage
 
 1. Click the PetaTas extension icon in the Chrome toolbar
 2. The Side Panel will open with the task manager interface
@@ -23,7 +29,7 @@ Markdown table-based task management with timers and side panel functionality.
 4. Use the timer buttons to track time spent on tasks
 5. Click "Export" to copy tasks back to clipboard as Markdown
 
-### 3. Sample Markdown Table
+### 4. Sample Markdown Table
 
 Copy this sample table and paste it into the extension:
 
@@ -36,7 +42,7 @@ Copy this sample table and paste it into the extension:
 | Deploy to production | todo | After all tests pass |
 ```
 
-### 4. Features
+### 5. Features
 
 - **Markdown Table Import**: Paste any Markdown table to create tasks
 - **Timer Tracking**: Start/stop timers for individual tasks
@@ -45,7 +51,7 @@ Copy this sample table and paste it into the extension:
 - **Export**: Copy tasks back to clipboard as Markdown
 - **Side Panel**: Native Chrome side panel integration
 
-### 4.1 Status & Timer Behavior
+### 5.1 Status & Timer Behavior
 
 - Start sets the task status to `in-progress`.
 - Stop returns the status to `todo` unless the task is already `done`.
@@ -54,21 +60,6 @@ Copy this sample table and paste it into the extension:
 - Marking a task as `done` via the checkbox stops any running timer.
 - Unchecking `done` switches the task back to `todo`; you can Start again as needed.
 
-### 5. File Structure
-
-```
-dist/
-├── manifest.json          # Chrome Extension manifest
-├── service-worker.js      # Background service worker
-├── panel-client.js        # Main client-side JavaScript
-├── index.html             # Side panel HTML (built)
-├── favicon.ico            # Extension favicon
-└── assets/                # Static assets
-    ├── index.<hash>.css   # Bundled CSS (hashed)
-    ├── icon-16.png
-    ├── icon-48.png
-    └── icon-128.png
-```
 
 ### 6. Development
 
@@ -78,14 +69,38 @@ The extension is built using:
   - Policy: favor utility classes and built-in themes; minimize custom CSS and avoid overriding core component classes. Prefer semantic classes (e.g., `badge-*`) and data attributes for state.
 - **TypeScript**: Type safety
 - **Chrome Extension Manifest V3**: Modern extension platform
-- **Vitest**: 171 passing tests with TDD approach
+- **Vitest**: Run `npm test` to execute the unit test suite developed with TDD
 
-### 6.1 Security (CSP)
+### 6.1 Local Development Workflow
+
+- `npm run dev`: Start the Astro dev server with hot reload
+- `npm test`: Run unit tests (jsdom environment)
+- `npm run lint`: Check lint rules
+- `npm run typecheck`: Perform type checking
+- `npm run build`: Generate the production bundle in `dist/`
+
+### 6.2 File Structure
+
+```
+src/
+├── components/            # UI components (.astro)
+├── pages/                 # Astro pages
+├── panel-client.ts        # Side panel bootstrap
+├── service-worker.ts      # Background service worker
+├── utils/                 # Shared utilities
+└── types/                 # Shared type definitions
+
+tests/                     # Vitest specs (jsdom)
+public/                    # Static assets copied as-is
+dist/                      # Production build output (after `npm run build`)
+```
+
+### 6.3 Security (CSP)
 
 - Extension pages use CSP with `style-src 'self' blob:` and do not include `'unsafe-inline'`.
 - Astro is configured with `inlineStylesheets: 'never'`; styles are emitted as external CSS.
 
-### 6.2 Permissions
+### 6.4 Permissions
 
 - To support reliable paste/copy, the manifest explicitly requests `clipboardRead` and `clipboardWrite`.
 - If organization policies restrict the clipboard, users may need to allow clipboard access in browser settings.
@@ -97,10 +112,8 @@ The extension is built using:
 - Verify Chrome is updated to support Manifest V3
 - Check that the extension has necessary permissions
 
-### 8. Next Steps
+### 8. Staying Up To Date
 
-1. Test in real browser environment
-2. Verify clipboard permissions work
-3. Test Side Panel API integration
-4. Add E2E tests with Playwright
-5. Performance optimizations
+- Follow the GitHub Issues/Projects board for open work items
+- Review the CI badges above for the latest build and test status
+- Capture larger roadmap discussions in `AGENTS.md` or project docs as they evolve


### PR DESCRIPTION
## Summary
- clarify build-before-load steps for Chrome
- document the local development commands and directory structure
- point readers to CI badges and project docs for current status

## Testing
- not run (docs only)
